### PR TITLE
Fix typo in CLI_Wallet.py

### DIFF
--- a/CLI_Wallet.py
+++ b/CLI_Wallet.py
@@ -345,7 +345,7 @@ while True:
                     if loginFeedback[0] == "OK":
                         print(Style.RESET_ALL
                               + Fore.YELLOW
-                              + "Successfull login")
+                              + "Successful login")
 
                         config['wallet'] = {
                             "username": username,


### PR DESCRIPTION
There was typo in the word 'Successful' in CLI_Wallet.py that was instead typed out as 'Successfull'.